### PR TITLE
align item details vertically

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -18,7 +18,7 @@
           <div mat-line class="mat-h3">
             {{ i.name }}
           </div>
-          <div class="mat-h3">
+          <div class="mat-p">
             {{ i.details }}
           </div>
         </mat-list-item>
@@ -29,7 +29,7 @@
           <div class="mat-h3" mat-line>
             {{ i.name }}
           </div>
-          <div class="mat-h3">
+          <div class="mat-p">
             {{ i.details }}
           </div>
         </mat-list-item>


### PR DESCRIPTION
<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
Changes proposed in this Pull Request:
started like this: 
![image](https://user-images.githubusercontent.com/8997218/69200556-814ade00-0b09-11ea-9e20-21ece23afbfe.png)
- class `mat-h3` will automatically add a margin at the bottom of the right element. Changed to `mat-p`.
